### PR TITLE
Feat config server

### DIFF
--- a/components/config_server/CMakeLists.txt
+++ b/components/config_server/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "src/config_server.c"
                     INCLUDE_DIRS "include"
-                    REQUIRES "esp_http_server"
+                    REQUIRES "esp_http_server" "tiny_json"
 )

--- a/components/config_server/CMakeLists.txt
+++ b/components/config_server/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(SRCS "src/config_server.c"
+                    INCLUDE_DIRS "include"
+                    REQUIRES "esp_http_server"
+)

--- a/components/config_server/include/config_server.h
+++ b/components/config_server/include/config_server.h
@@ -3,7 +3,17 @@
 #include "esp_err.h"
 #include "esp_http_server.h"
 
-httpd_handle_t create_config_server_handle(void);
+// static configuration struct
+typedef struct {
+  bool active;
+} app_config_t;
 
+static app_config_t config = {
+    .active = true,
+};
+
+const app_config_t *get_config();
+
+httpd_handle_t create_config_server_handle(void);
 esp_err_t start_config_server(httpd_handle_t *server);
 esp_err_t stop_config_server(httpd_handle_t *server);

--- a/components/config_server/include/config_server.h
+++ b/components/config_server/include/config_server.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "esp_err.h"
+#include "esp_http_server.h"
+
+httpd_handle_t create_config_server_handle(void);
+
+esp_err_t start_config_server(httpd_handle_t *server);
+esp_err_t stop_config_server(httpd_handle_t *server);

--- a/components/config_server/src/config_server.c
+++ b/components/config_server/src/config_server.c
@@ -1,0 +1,52 @@
+#include "config_server.h"
+
+#include "esp_log.h"
+
+static const char *TAG = "CONFIG_SERVER";
+
+/* Our URI handler function to be called during GET /uri request */
+esp_err_t get_handler(httpd_req_t *req) {
+  /* Send a simple response */
+  const char resp[] = "URI GET Response";
+  httpd_resp_send(req, resp, HTTPD_RESP_USE_STRLEN);
+  return ESP_OK;
+}
+
+/* URI handler structure for GET /uri */
+httpd_uri_t uri_get = {.uri = "/uri",
+                       .method = HTTP_GET,
+                       .handler = get_handler,
+                       .user_ctx = NULL};
+
+httpd_handle_t create_config_server_handle(void) {
+  httpd_handle_t server = NULL;
+  return server;
+}
+
+esp_err_t start_config_server(httpd_handle_t *server) {
+  /* Generate default configuration */
+  httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+
+  esp_err_t server_start_err = httpd_start(server, &config);
+
+  if (server_start_err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to start server : %s",
+             esp_err_to_name(server_start_err));
+    return server_start_err;
+  }
+  ESP_LOGI(TAG, "Config Server started");
+
+  /* URI handler structure for GET /uri */
+  httpd_uri_t uri_get = {.uri = "/uri",
+                         .method = HTTP_GET,
+                         .handler = get_handler,
+                         .user_ctx = NULL};
+
+  ESP_ERROR_CHECK(httpd_register_uri_handler(*server, &uri_get));
+
+  return ESP_OK;
+}
+
+esp_err_t stop_config_server(httpd_handle_t *server) {
+  return httpd_stop(server);
+}

--- a/components/config_server/src/config_server.c
+++ b/components/config_server/src/config_server.c
@@ -1,22 +1,93 @@
 #include "config_server.h"
 
 #include "esp_log.h"
+#include "tiny_json.h"
+#include <string.h>
+
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
 static const char *TAG = "CONFIG_SERVER";
 
-/* Our URI handler function to be called during GET /uri request */
-esp_err_t get_handler(httpd_req_t *req) {
+// format the status struct as JSON
+char *format_status_response(void) {
+  char *response = malloc(100);
+  snprintf(response, 100, "{\"active\": %s}", config.active ? "true" : "false");
+  return response;
+}
+
+const app_config_t *get_config() { return &config; }
+
+esp_err_t get_status_handler(httpd_req_t *req) {
   /* Send a simple response */
-  const char resp[] = "URI GET Response";
+  httpd_resp_set_hdr(req, "Connection", "keep-alive");
+  char *resp = format_status_response();
   httpd_resp_send(req, resp, HTTPD_RESP_USE_STRLEN);
+  free(resp);
   return ESP_OK;
 }
 
-/* URI handler structure for GET /uri */
-httpd_uri_t uri_get = {.uri = "/uri",
-                       .method = HTTP_GET,
-                       .handler = get_handler,
-                       .user_ctx = NULL};
+esp_err_t set_status_handler(httpd_req_t *req) {
+  char content[200];
+
+  bool found_p_in_body = false;
+
+  /* Truncate if content length larger than the buffer */
+  size_t recv_size = MIN(req->content_len, sizeof(content));
+  int ret = httpd_req_recv(req, content, recv_size);
+  if (ret <= 0) {
+    ESP_LOGE(TAG, "set_status_handler: Failed to receive data");
+    return ESP_FAIL;
+  }
+
+  // append null terminator to content buffer
+  content[recv_size] = '\0';
+
+  json_t mem[20]; // TODO increase if extending JSON object
+  json_t const *json = json_create(content, mem, sizeof mem / sizeof *mem);
+  if (!json) {
+    ESP_LOGE(TAG, "Failed to create JSON object");
+    const char resp[] = "invalid JSON";
+    httpd_resp_set_status(req, HTTPD_400);
+    httpd_resp_send(req, resp, HTTPD_RESP_USE_STRLEN);
+    return ESP_FAIL;
+  }
+
+  json_t const *active_field = json_getProperty(json, "active");
+  if (active_field && JSON_BOOLEAN == json_getType(active_field)) {
+    found_p_in_body = true;
+    ESP_LOGD(TAG, "Setting active to %s",
+             json_getBoolean(active_field) ? "true" : "false");
+    config.active = json_getBoolean(active_field);
+  } else {
+    ESP_LOGD(TAG, "No active field found");
+  }
+
+  if (!found_p_in_body) {
+    ESP_LOGE(TAG, "No config field found in body");
+    const char resp[] = "No config field found in body";
+    httpd_resp_set_status(req, HTTPD_400);
+    httpd_resp_send(req, resp, HTTPD_RESP_USE_STRLEN);
+    return ESP_FAIL;
+  }
+
+  /* Send a simple response */
+  const char *resp = format_status_response();
+  httpd_resp_send(req, resp, HTTPD_RESP_USE_STRLEN);
+  free(resp);
+  return ESP_OK;
+}
+
+/* URI handler structure for GET /status */
+httpd_uri_t status_get = {.uri = "/status",
+                          .method = HTTP_GET,
+                          .handler = get_status_handler,
+                          .user_ctx = NULL};
+
+/* URI handler structure for POST /status */
+httpd_uri_t active_post = {.uri = "/status",
+                           .method = HTTP_POST,
+                           .handler = set_status_handler,
+                           .user_ctx = NULL};
 
 httpd_handle_t create_config_server_handle(void) {
   httpd_handle_t server = NULL;
@@ -26,6 +97,11 @@ httpd_handle_t create_config_server_handle(void) {
 esp_err_t start_config_server(httpd_handle_t *server) {
   /* Generate default configuration */
   httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+  // depending on max open sockets in lwip configuration (menuconfig)
+  config.max_open_sockets = 10;
+  // purge oldest socket if max open sockets is reached
+  // otherwise new connections will stall
+  config.lru_purge_enable = true;
 
   esp_err_t server_start_err = httpd_start(server, &config);
 
@@ -36,13 +112,8 @@ esp_err_t start_config_server(httpd_handle_t *server) {
   }
   ESP_LOGI(TAG, "Config Server started");
 
-  /* URI handler structure for GET /uri */
-  httpd_uri_t uri_get = {.uri = "/uri",
-                         .method = HTTP_GET,
-                         .handler = get_handler,
-                         .user_ctx = NULL};
-
-  ESP_ERROR_CHECK(httpd_register_uri_handler(*server, &uri_get));
+  ESP_ERROR_CHECK(httpd_register_uri_handler(*server, &status_get));
+  ESP_ERROR_CHECK(httpd_register_uri_handler(*server, &active_post));
 
   return ESP_OK;
 }

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "main.c"
                        INCLUDE_DIRS "."
-                       REQUIRES "nvs_flash" "wifi_connector" "hue_api" "bootloader_support" "esp_timer" "motion_sensor" "ssd1306_driver"
+                       REQUIRES "nvs_flash" "wifi_connector" "hue_api" "bootloader_support" "esp_timer" "motion_sensor" "ssd1306_driver" "config_server"
 )

--- a/main/main.c
+++ b/main/main.c
@@ -23,7 +23,9 @@
 #include "ssd1306_driver.h"
 #include "wifi_connector.h"
 
-static const char *TAG = "TODO";
+#define DRY_RUN true
+
+static const char *TAG = "MAIN";
 
 TaskHandle_t activateLightTaskHandle, deactivateGroupedLightTaskHandle,
     checkMotionTaskHandle;
@@ -45,7 +47,11 @@ void activateLightTask(void *parameters) {
   esp_http_client_handle_t client = esp_http_client_init(&cfg);
   while (1) {
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-    turn_on_grouped_light(&client, "1ad5cedd-1053-42fe-8319-5997facf8423");
+    if (DRY_RUN) {
+      ESP_LOGI(TAG, "Dry run: Activating light");
+    } else {
+      turn_on_grouped_light(&client, "1ad5cedd-1053-42fe-8319-5997facf8423");
+    }
   }
 }
 
@@ -54,7 +60,11 @@ void deactivateGroupedLightTask(void *parameters) {
   esp_http_client_handle_t client = esp_http_client_init(&cfg);
   while (1) {
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-    turn_off_grouped_light(&client, "1ad5cedd-1053-42fe-8319-5997facf8423");
+    if (DRY_RUN) {
+      ESP_LOGI(TAG, "Dry run: Deactivating light");
+    } else {
+      turn_off_grouped_light(&client, "1ad5cedd-1053-42fe-8319-5997facf8423");
+    }
   }
 }
 

--- a/wokwi.toml
+++ b/wokwi.toml
@@ -2,3 +2,8 @@
 version = 1
 firmware = 'build/flasher_args.json'
 elf = 'build/esp_hue_motion_control.elf'
+
+# Forward http://localhost:8180 to port 80 on the simulated ESP32:
+[[net.forward]]
+from = "localhost:8180"
+to = "target:80"


### PR DESCRIPTION
This pull request introduces a new configuration server to the project, allowing for dynamic control of the application configuration via HTTP endpoints. The changes include updates to the build configuration, header and source files for the new server, and modifications to the main application to integrate the configuration server.

### Configuration Server Implementation:

* [`components/config_server/CMakeLists.txt`](diffhunk://#diff-a1d696cd74f04ff4027ca065c0c6e01375b021d88b2ea79e2b0e0e082b932c09R1-R4): Registered the new `config_server` component with its source files and dependencies.
* [`components/config_server/include/config_server.h`](diffhunk://#diff-73251754f9af3bce19c9cd3fddb522ef4dbb12712890c620b00ee2e29abf6688R1-R19): Added the header file for the configuration server, defining the configuration structure and function prototypes.
* [`components/config_server/src/config_server.c`](diffhunk://#diff-61d1b6c3d8ab0e194f087796badbdad441d85766c793647574508a32cfbb76e8R1-R123): Implemented the configuration server, including HTTP handlers for getting and setting the configuration, and functions to start and stop the server.

### Integration with Main Application:

* [`main/CMakeLists.txt`](diffhunk://#diff-e1bc61f89706898f754134386b0c25982fa6dd53e2c7172f66d36a9f6b773dc5L3-R3): Added the `config_server` component as a requirement for the main application.
* [`main/main.c`](diffhunk://#diff-2978fe1c2c45b4eca89dc476376ddc7193bc4e5e7fff0c7d1c465f057b35a5e6R19-R31): Integrated the configuration server into the main application, including starting the server in `app_main`, and checking the configuration in task handlers. [[1]](diffhunk://#diff-2978fe1c2c45b4eca89dc476376ddc7193bc4e5e7fff0c7d1c465f057b35a5e6R19-R31) [[2]](diffhunk://#diff-2978fe1c2c45b4eca89dc476376ddc7193bc4e5e7fff0c7d1c465f057b35a5e6R53-R84) [[3]](diffhunk://#diff-2978fe1c2c45b4eca89dc476376ddc7193bc4e5e7fff0c7d1c465f057b35a5e6L110-R138)

### Additional Changes:

* [`wokwi.toml`](diffhunk://#diff-d19cc9bac4e654de2a2e1a2081eb906a21cd0a88cd1055fcf3d26d65cad82248R5-R9): Configured port forwarding for the simulated ESP32 to enable HTTP access to the configuration server.